### PR TITLE
Accounts for asynchronous load of jQuery

### DIFF
--- a/pi.video.php
+++ b/pi.video.php
@@ -66,13 +66,28 @@ class Plugin_Video extends Plugin {
 			if ($responsive) {
 				//Implemented using FitVids.js
 				$html .= '
-				<script src="_add-ons/video/js/jquery.fitvids.min.js"></script>
 				<script>
-				$(document).ready(function(){
-					// Target your .container, .wrapper, .post, etc.
-					$("body").fitVids();
-				  });
-				</script>
+				var initializeFitvids = function() {
+			            if ($("body").fitVids()) {
+			                $("body").fitVids();
+			            } else {
+			                window.setTimeout(initializeFitvids, 50)
+			            }
+			        };
+	
+				var loadFitvids = function() {
+			            if (window.$) {
+			                $.getScript("_add-ons/video/js/jquery.fitvids.min.js")
+			                $(document).ready(function(){
+				                // Target your .container, .wrapper, .post, etc.
+			        			initializeFitvids();
+				            });
+			            } else {
+			                window.setTimeout(loadFitvids, 50)
+			            }
+			        };
+			        loadFitvids();
+			        </script>
 				';
 			}
 			return $html;
@@ -115,13 +130,28 @@ class Plugin_Video extends Plugin {
 			if ($responsive) {
 				//Implemented using FitVids.js
 				$html .= '
-				<script src="_add-ons/video/js/jquery.fitvids.min.js"></script>
 				<script>
-				$(document).ready(function(){
-					// Target your .container, .wrapper, .post, etc.
-					$("body").fitVids();
-				  });
-				</script>
+				var initializeFitvids = function() {
+			            if ($("body").fitVids()) {
+			                $("body").fitVids();
+			            } else {
+			                window.setTimeout(initializeFitvids, 50)
+			            }
+			        };
+	
+				var loadFitvids = function() {
+			            if (window.$) {
+			                $.getScript("_add-ons/video/js/jquery.fitvids.min.js")
+			                $(document).ready(function(){
+				                // Target your .container, .wrapper, .post, etc.
+			        			initializeFitvids();
+				            });
+			            } else {
+			                window.setTimeout(loadFitvids, 50)
+			            }
+			        };
+			        loadFitvids();
+			        </script>
 				';
 			}
 			return $html;


### PR DESCRIPTION
This accounts for the case where jQuery is not yet loaded when the plugin tries to load and initialize fitVids which prevents fitVids from working. Here, the injected scripts first test for jQuery before fetching the fitVids script. Once the script has been fetched, another check is made for fitVids. Only after this test has passed will fitVids be initialized on the body. The tests will each re-run every 50ms until the pass condition is met.

I have not tested this with a synchronous load of jQuery, but it should still work in that case as well.
