### PR TITLE
Fixed relative path issue with FitVids script

### DIFF
--- a/pi.video.php
+++ b/pi.video.php
@@ -78,7 +78,7 @@ class Plugin_Video extends Plugin {
 	
 				var loadFitvids = function() {
 			            if (window.$) {
-			                $.getScript("_add-ons/video/js/jquery.fitvids.min.js")
+			                $.getScript("/_add-ons/video/js/jquery.fitvids.min.js")
 			                $(document).ready(function(){
 				                // Target your .container, .wrapper, .post, etc.
 			        			initializeFitvids();
@@ -221,7 +221,7 @@ class Plugin_Video extends Plugin {
 	
 				var loadFitvids = function() {
 			            if (window.$) {
-			                $.getScript("_add-ons/video/js/jquery.fitvids.min.js")
+			                $.getScript("/_add-ons/video/js/jquery.fitvids.min.js")
 			                $(document).ready(function(){
 				                // Target your .container, .wrapper, .post, etc.
 			        			initializeFitvids();


### PR DESCRIPTION
When videos load in an individual entry or page, FitVids script 404s due to relative path. This change looks to [root]/_add-ons instead.
